### PR TITLE
Fix external links

### DIFF
--- a/lib/glo-atom-view.js
+++ b/lib/glo-atom-view.js
@@ -1,11 +1,15 @@
 'use babel';
 
+import { shell } from 'electron';
 import path from 'path';
 import config from '../config';
 import { DISPLAY_NAME, VIEW_URI } from './constants';
 
 const onIpcMessage = ({ channel, args }) => {
   // custom ipc handlers here
+  if (channel === 'shell.openExternal') {
+    shell.openExternal(args[0]);
+  }
 };
 
 export default class GloAtomView {

--- a/lib/webviewPreload.js
+++ b/lib/webviewPreload.js
@@ -1,5 +1,9 @@
 const { ipcRenderer } = require('electron');
 
-window.sendToHost = function() {
-  ipcRenderer.sendToHost.apply(ipcRenderer, arguments);
-}
+window.HostIPC = {
+  version: '0.0.1',
+  name: 'Atom',
+  sendToHost: (...args) => ipcRenderer.sendToHost(...args),
+  on: (...args) => ipcRenderer.on(...args),
+  once: (...args) => ipcRenderer.once(...args)
+};


### PR DESCRIPTION
Links in places like description and comments didn't do anything when the user clicked on them. This is because we weren't handling that event at all in Atom.
Now, they will open in your browser (same behavior as GK).

To test:
1. checkout this PR branch
2. open the repo in a terminal
3. `apm link`
4. restart Atom

You might need to temporarily disable your current Glo plugin if you have it installed.